### PR TITLE
fix/next-version 404ページの表示のラグ修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "framer-motion": "^10.15.1",
-        "next": "13.4.13",
+        "next": "13.4.15",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -4263,14 +4263,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.13.tgz",
-      "integrity": "sha512-fwz2QgVg08v7ZL7KmbQBLF2PubR/6zQdKBgmHEl3BCyWTEDsAQEijjw2gbFhI1tcKfLdOOJUXntz5vZ4S0Polg=="
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.15.tgz",
+      "integrity": "sha512-GQXUy/y5NW4VbrKQMbLjsuTykJ7+Jtb9zcKH1WrmgI1zG7yCoZQaoI65YFNksEh+9EPSHX6Xr7U1/StIIAOXog=="
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.13.tgz",
-      "integrity": "sha512-ZptVhHjzUuivnXMNCJ6lER33HN7lC+rZ01z+PM10Ows21NHFYMvGhi5iXkGtBDk6VmtzsbqnAjnx4Oz5um0FjA==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.15.tgz",
+      "integrity": "sha512-S4/5CwFxUtV+MnXXv5a+zGpx8Swm6WfzKYrcKbyYgl71Ek7bj0TrqZXASD2HeXIlHwr+0SJnnhSFcU09Y4tHjA==",
       "cpu": [
         "arm64"
       ],
@@ -4283,9 +4283,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.13.tgz",
-      "integrity": "sha512-t9nTiWCLApw8W4G1kqJyYP7y6/7lyal3PftmRturIxAIBlZss9wrtVN8nci50StDHmIlIDxfguYIEGVr9DbFTg==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.15.tgz",
+      "integrity": "sha512-6bAi8s3vVRMFPU5qr4hZsfsQ0tzLU/Ig3tHjpJyjIN9AV3PMbTnX716P7hj1QioLfzZxIcUVnDczW7L45xHVfQ==",
       "cpu": [
         "x64"
       ],
@@ -4298,9 +4298,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.13.tgz",
-      "integrity": "sha512-xEHUqC8eqR5DHe8SOmMnDU1K3ggrJ28uIKltrQAwqFSSSmzjnN/XMocZkcVhuncuxYrpbri0iMQstRyRVdQVWg==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.15.tgz",
+      "integrity": "sha512-LpMjwqsQAj269h0PIqw8drRGGpyg6cRHi8JEAKtD/putcCalQWCplfUzjtML8jplwMN1lcdPDNtFIab53t8AzQ==",
       "cpu": [
         "arm64"
       ],
@@ -4313,9 +4313,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.13.tgz",
-      "integrity": "sha512-sNf3MnLAm8rquSSAoeD9nVcdaDeRYOeey4stOWOyWIgbBDtP+C93amSgH/LPTDoUV7gNiU6f+ghepTjTjRgIUQ==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.15.tgz",
+      "integrity": "sha512-zpV8C34OtLhu+1oiXIdDC576s88/TYxN325kipuL64Zs/j2kSEinR28mcLCZQTYI2g4OwtE3XIERy4vFoY3WiA==",
       "cpu": [
         "arm64"
       ],
@@ -4328,9 +4328,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.13.tgz",
-      "integrity": "sha512-WhcRaJJSHyx9OWmKjjz+OWHumiPZWRqmM/09Bt7Up4UqUJFFhGExeztR4trtv3rflvULatu9IH/nTV8fUUgaMA==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.15.tgz",
+      "integrity": "sha512-Xk7QEfbX3zotvLmCoLzeGefbdyPpclCR8WyWHQOMMwUpftfmAuEVyU29WegcdfNCqYwc2QDXseVVI7xW/VwHCA==",
       "cpu": [
         "x64"
       ],
@@ -4343,9 +4343,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.13.tgz",
-      "integrity": "sha512-+Y4LLhOWWZQIDKVwr2R17lq2KSN0F1c30QVgGIWfnjjHpH8nrIWHEndhqYU+iFuW8It78CiJjQKTw4f51HD7jA==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.15.tgz",
+      "integrity": "sha512-SxXxWBIUICkbHPUthg+T/FuRgOp75wE0e6eiLGs4P9Miq/P3kSXHv6x5LRnDreGDvYnKOlpzXlsXTxcPTRWttg==",
       "cpu": [
         "x64"
       ],
@@ -4358,9 +4358,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.13.tgz",
-      "integrity": "sha512-rWurdOR20uxjfqd1X9vDAgv0Jb26KjyL8akF9CBeFqX8rVaBAnW/Wf6A2gYEwyYY4Bai3T7p1kro6DFrsvBAAw==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.15.tgz",
+      "integrity": "sha512-Pu8zaW59XKbycyW/vzKRQOcbaZA2n3BK1zAFxv+hAO2bQ29FSGrtRb2nfhMDLwN0ggWIHKVKb+h4WMFHZkS9Qw==",
       "cpu": [
         "arm64"
       ],
@@ -4373,9 +4373,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.13.tgz",
-      "integrity": "sha512-E8bSPwRuY5ibJ3CzLQmJEt8qaWrPYuUTwnrwygPUEWoLzD5YRx9SD37oXRdU81TgGwDzCxpl7z5Nqlfk50xAog==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.15.tgz",
+      "integrity": "sha512-V3y1Sc0X31mwK4cx0JQBi0wSTbPpmp/qRXjS0Vz3+2oSrbV06Oz27c/r2tW7ph0qhVp8+Jt03ZLnSc7KjjECiA==",
       "cpu": [
         "ia32"
       ],
@@ -4388,9 +4388,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.13.tgz",
-      "integrity": "sha512-4KlyC6jWRubPnppgfYsNTPeWfGCxtWLh5vaOAW/kdzAk9widqho8Qb5S4K2vHmal1tsURi7Onk2MMCV1phvyqA==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.15.tgz",
+      "integrity": "sha512-mUGemqDIuD2PjnqEkqMpeI8cXOTVjedo9cqoaMkrOVcoK1IX/w7h4qYeniMUCImamsDAoLms86Fq9LzxT24StQ==",
       "cpu": [
         "x64"
       ],
@@ -13133,11 +13133,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.13.tgz",
-      "integrity": "sha512-A3YVbVDNeXLhWsZ8Nf6IkxmNlmTNz0yVg186NJ97tGZqPDdPzTrHotJ+A1cuJm2XfuWPrKOUZILl5iBQkIf8Jw==",
+      "version": "13.4.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.15.tgz",
+      "integrity": "sha512-s4ZSBwZrvpY0IDzRtD7C5CY8FA/8ZIYqrJZHnwrf6mkUVA+Y+A6CtwBYyxml6VKgP/3DFNqCqkBQGInZuPHzmQ==",
       "dependencies": {
-        "@next/env": "13.4.13",
+        "@next/env": "13.4.15",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
@@ -13153,15 +13153,15 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.13",
-        "@next/swc-darwin-x64": "13.4.13",
-        "@next/swc-linux-arm64-gnu": "13.4.13",
-        "@next/swc-linux-arm64-musl": "13.4.13",
-        "@next/swc-linux-x64-gnu": "13.4.13",
-        "@next/swc-linux-x64-musl": "13.4.13",
-        "@next/swc-win32-arm64-msvc": "13.4.13",
-        "@next/swc-win32-ia32-msvc": "13.4.13",
-        "@next/swc-win32-x64-msvc": "13.4.13"
+        "@next/swc-darwin-arm64": "13.4.15",
+        "@next/swc-darwin-x64": "13.4.15",
+        "@next/swc-linux-arm64-gnu": "13.4.15",
+        "@next/swc-linux-arm64-musl": "13.4.15",
+        "@next/swc-linux-x64-gnu": "13.4.15",
+        "@next/swc-linux-x64-musl": "13.4.15",
+        "@next/swc-win32-arm64-msvc": "13.4.15",
+        "@next/swc-win32-ia32-msvc": "13.4.15",
+        "@next/swc-win32-x64-msvc": "13.4.15"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "framer-motion": "^10.15.1",
-    "next": "13.4.13",
+    "next": "13.4.18",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
### やったこと
404ページを表示した時にスタイルの反映に時間がかかっていました。
原因がnext.jsのバージョンだった為、バージョンを13.4.13から13.4.15へアップしました。
これによってスタイル反映のラグが解消されました。
![スクリーンショット 2023-08-14 1 19 34](https://github.com/if-mentor/next_todo_11/assets/66238714/d02ffdd8-3b4a-4baa-9d12-19518e76ef8c)
